### PR TITLE
PCI-323 Validate CertificateItemDTO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-library</artifactId>
 			<version>${hamcrest-library-version}</version>

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/controller/ApiError.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/controller/ApiError.java
@@ -1,0 +1,29 @@
+package uk.gov.companieshouse.items.orders.api.controller;
+
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+/**
+ * Wraps up status and list of messages for rendering in non-2xx REST response payload.
+ */
+public class ApiError {
+
+    private final HttpStatus status;
+    private final List<String> errors;
+
+    public ApiError(final HttpStatus status, final List<String> errors) {
+        super();
+        this.status = status;
+        this.errors = errors;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsController.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsController.java
@@ -9,6 +9,8 @@ import uk.gov.companieshouse.items.orders.api.dto.CertificateItemDTO;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
+import javax.validation.Valid;
+
 import static uk.gov.companieshouse.items.orders.api.ItemType.CERTIFICATE;
 import static uk.gov.companieshouse.items.orders.api.ItemsApiApplication.APPLICATION_NAMESPACE;
 
@@ -19,7 +21,7 @@ public class CertificateItemsController {
 
     @PostMapping("${uk.gov.companieshouse.items.orders.api.path}")
     @ResponseStatus(HttpStatus.CREATED)
-    public CertificateItemDTO createCertificateItem(final @RequestBody CertificateItemDTO certificateItemDTO) {
+    public CertificateItemDTO createCertificateItem(final @Valid @RequestBody CertificateItemDTO certificateItemDTO) {
 
         LOGGER.info("ENTERING createCertificateItem(" + certificateItemDTO + ")");
 

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsController.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsController.java
@@ -1,15 +1,17 @@
 package uk.gov.companieshouse.items.orders.api.controller;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.items.orders.api.dto.CertificateItemDTO;
+import uk.gov.companieshouse.items.orders.api.validator.CreateItemRequestValidator;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
 import javax.validation.Valid;
+import java.util.List;
 
 import static uk.gov.companieshouse.items.orders.api.ItemType.CERTIFICATE;
 import static uk.gov.companieshouse.items.orders.api.ItemsApiApplication.APPLICATION_NAMESPACE;
@@ -19,11 +21,21 @@ public class CertificateItemsController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAMESPACE);
 
+    private final CreateItemRequestValidator validator;
+
+    public CertificateItemsController(CreateItemRequestValidator validator) {
+        this.validator = validator;
+    }
+
     @PostMapping("${uk.gov.companieshouse.items.orders.api.path}")
-    @ResponseStatus(HttpStatus.CREATED)
-    public CertificateItemDTO createCertificateItem(final @Valid @RequestBody CertificateItemDTO certificateItemDTO) {
+    public ResponseEntity<Object> createCertificateItem(final @Valid @RequestBody CertificateItemDTO certificateItemDTO) {
 
         LOGGER.info("ENTERING createCertificateItem(" + certificateItemDTO + ")");
+
+        final List<String> errors = validator.getValidationErrors(certificateItemDTO);
+        if (!errors.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiError(HttpStatus.BAD_REQUEST, errors));
+        }
 
         CERTIFICATE.populateReadOnlyFields(certificateItemDTO);
 
@@ -32,7 +44,7 @@ public class CertificateItemsController {
         certificateItemDTO.setId("CHS1");
 
         LOGGER.info("EXITING createCertificateItem() with " + certificateItemDTO);
-        return certificateItemDTO;
+        return ResponseEntity.status(HttpStatus.CREATED).body(certificateItemDTO);
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/controller/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/controller/GlobalExceptionHandler.java
@@ -1,0 +1,45 @@
+package uk.gov.companieshouse.items.orders.api.controller;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import uk.gov.companieshouse.items.orders.api.util.FieldNameConverter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    private final FieldNameConverter converter;
+
+    public GlobalExceptionHandler(FieldNameConverter converter) {
+        this.converter = converter;
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            final MethodArgumentNotValidException ex,
+            final HttpHeaders headers,
+            final HttpStatus status,
+            final WebRequest request) {
+        final List<String> errors = new ArrayList<>();
+        for (final FieldError error : ex.getBindingResult().getFieldErrors()) {
+            errors.add(converter.toSnakeCase(error.getField()) + ": " + error.getDefaultMessage());
+        }
+        for (final ObjectError error : ex.getBindingResult().getGlobalErrors()) {
+            errors.add(error.getObjectName() + ": " + error.getDefaultMessage());
+        }
+
+        final ApiError apiError =
+                new ApiError(HttpStatus.BAD_REQUEST, errors);
+        return handleExceptionInternal(ex, apiError, headers, apiError.getStatus(), request);
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/dto/CertificateItemDTO.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/dto/CertificateItemDTO.java
@@ -17,12 +17,24 @@ public class CertificateItemDTO extends ItemDTO {
     @JsonProperty("item_options")
     private CertificateItemOptions itemOptions;
 
+    @NotNull
+    @JsonProperty("company_number")
+    private String companyNumber;
+
     public CertificateItemOptions getItemOptions() {
         return itemOptions;
     }
 
     public void setItemOptions(CertificateItemOptions itemOptions) {
         this.itemOptions = itemOptions;
+    }
+
+    public String getCompanyNumber() {
+        return companyNumber;
+    }
+
+    public void setCompanyNumber(String companyNumber) {
+        this.companyNumber = companyNumber;
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/dto/CertificateItemDTO.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/dto/CertificateItemDTO.java
@@ -5,12 +5,15 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.gson.Gson;
 import uk.gov.companieshouse.items.orders.api.model.CertificateItemOptions;
 
+import javax.validation.constraints.NotNull;
+
 /**
  * An instance of this represents the JSON serializable certificate item for use in REST requests and responses.
  */
 @JsonPropertyOrder(alphabetic = true)
 public class CertificateItemDTO extends ItemDTO {
 
+    @NotNull
     @JsonProperty("item_options")
     private CertificateItemOptions itemOptions;
 

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/dto/ItemDTO.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/dto/ItemDTO.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.Gson;
 import uk.gov.companieshouse.items.orders.api.model.ItemCosts;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import java.util.Map;
 
 /**
@@ -25,6 +27,7 @@ public class ItemDTO {
     @JsonProperty("description_values")
     private Map<String, String> descriptionValues;
 
+    @NotNull
     @JsonProperty("item_costs")
     private ItemCosts itemCosts;
 
@@ -33,6 +36,7 @@ public class ItemDTO {
 
     private boolean isPostalDelivery;
 
+    @Min(1)
     @JsonProperty("quantity")
     private int quantity;
 

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/dto/ItemDTO.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/dto/ItemDTO.java
@@ -5,7 +5,6 @@ import com.google.gson.Gson;
 import uk.gov.companieshouse.items.orders.api.model.ItemCosts;
 
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
 import java.util.Map;
 
 /**
@@ -27,7 +26,6 @@ public class ItemDTO {
     @JsonProperty("description_values")
     private Map<String, String> descriptionValues;
 
-    @NotNull
     @JsonProperty("item_costs")
     private ItemCosts itemCosts;
 

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/dto/ItemDTO.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/dto/ItemDTO.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.items.orders.api.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.gson.Gson;
 import uk.gov.companieshouse.items.orders.api.model.ItemCosts;
 
 import javax.validation.constraints.Min;
@@ -105,6 +104,4 @@ public class ItemDTO {
         this.quantity = quantity;
     }
 
-    @Override
-    public String toString() { return new Gson().toJson(this); }
 }

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/dto/ItemDTO.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/dto/ItemDTO.java
@@ -14,9 +14,6 @@ public class ItemDTO {
 
     private String id;
 
-    @JsonProperty("company_number")
-    private String companyNumber;
-
     @JsonProperty("description")
     private String description;
 
@@ -44,14 +41,6 @@ public class ItemDTO {
 
     public void setId(String id) {
         this.id = id;
-    }
-
-    public String getCompanyNumber() {
-        return companyNumber;
-    }
-
-    public void setCompanyNumber(String companyNumber) {
-        this.companyNumber = companyNumber;
     }
 
     public String getDescription() {

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/dto/ItemDTO.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/dto/ItemDTO.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import uk.gov.companieshouse.items.orders.api.model.ItemCosts;
 
 import javax.validation.constraints.Min;
+import javax.validation.constraints.Null;
 import java.util.Map;
 
 /**
@@ -14,15 +15,19 @@ public class ItemDTO {
 
     private String id;
 
+    @Null
     @JsonProperty("description")
     private String description;
 
+    @Null
     @JsonProperty("description_identifier")
     private String descriptionIdentifier;
 
+    @Null
     @JsonProperty("description_values")
     private Map<String, String> descriptionValues;
 
+    @Null
     @JsonProperty("item_costs")
     private ItemCosts itemCosts;
 

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/util/FieldNameConverter.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/util/FieldNameConverter.java
@@ -1,0 +1,26 @@
+package uk.gov.companieshouse.items.orders.api.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class FieldNameConverter {
+
+    /**
+     * Converts the field name provided to its corresponding snake case representation.
+     * Currently limited to a maximum of two words in the name.
+     * @param fieldName the name of the field to be converted (typically camel case)
+     * @return the field name's snake case representation
+     */
+    public String toSnakeCase(final String fieldName) {
+        final Pattern pattern = Pattern.compile("(.+?)([A-Z][a-z]+)");
+        final Matcher matcher = pattern.matcher(fieldName);
+        if (!matcher.matches()) {
+            return fieldName;
+        }
+        return matcher.group(1) + "_" + matcher.group(2).toLowerCase();
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/validator/CreateItemRequestValidator.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/validator/CreateItemRequestValidator.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.items.orders.api.validator;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.items.orders.api.dto.ItemDTO;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Implements validation of the request payload specific to the the create item request only.
+ */
+@Component
+public class CreateItemRequestValidator {
+
+    /**
+     * Validates the item provided, returning any errors found.
+     * @param item the item to be validated
+     * @return the errors found, which will be empty if the item is found to be valid
+     */
+    public List<String> getValidationErrors(final ItemDTO item) {
+        final List<String> errors = new ArrayList<>();
+        if (item.getId() != null) {
+            errors.add("id: must be null in a create item request");
+        }
+        return errors;
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/ItemsApiApplicationTests.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/ItemsApiApplicationTests.java
@@ -175,6 +175,24 @@ class ItemsApiApplicationTests {
 		postBadCreateRequestAndExpectError(newCertificateItemDTO, "description_values: must be null");
 	}
 
+	@Test
+	@DisplayName("Create rejects read only id")
+	void createCertificateItemRejectsReadOnlyId() {
+
+		// Given
+		final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
+		newCertificateItemDTO.setCompanyNumber("1234");
+		newCertificateItemDTO.setId("TEST_ID");
+		final CertificateItemOptions options = new CertificateItemOptions();
+		options.setCertInc(true);
+		options.setCertShar(true);
+		newCertificateItemDTO.setItemOptions(options);
+		newCertificateItemDTO.setQuantity(5);
+
+		// When and Then
+		postBadCreateRequestAndExpectError(newCertificateItemDTO, "id: must be null in a create item request");
+	}
+
 	/**
 	 * Utility method that posts the create certificate item request, asserts a bad request status response and an
 	 * expected validation error message.

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/ItemsApiApplicationTests.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/ItemsApiApplicationTests.java
@@ -42,16 +42,8 @@ class ItemsApiApplicationTests {
         newCertificateItemDTO.setItemOptions(options);
         newCertificateItemDTO.setQuantity(5);
 
-        // When and Then
-        webTestClient.post().uri("/orderable/certificates")
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(fromValue(newCertificateItemDTO))
-                .exchange()
-                .expectStatus().isBadRequest()
-                .expectBody()
-                .jsonPath("$.error").isEqualTo("Bad Request")
-                .jsonPath("$.errors[0].field").isEqualTo("companyNumber");
-
+		// When and Then
+		postBadCreateRequestAndExpectError(newCertificateItemDTO, "company_number: must not be null");
     }
 
 	@Test
@@ -86,15 +78,7 @@ class ItemsApiApplicationTests {
 		newCertificateItemDTO.setQuantity(5);
 
 		// When and Then
-		webTestClient.post().uri("/orderable/certificates")
-				.contentType(MediaType.APPLICATION_JSON)
-				.body(fromValue(newCertificateItemDTO))
-				.exchange()
-				.expectStatus().isBadRequest()
-				.expectBody()
-				.jsonPath("$.error").isEqualTo("Bad Request")
-				.jsonPath("$.errors[0].field").isEqualTo("itemOptions");
-
+		postBadCreateRequestAndExpectError(newCertificateItemDTO, "item_options: must not be null");
 	}
 
 	@Test
@@ -110,15 +94,7 @@ class ItemsApiApplicationTests {
 		newCertificateItemDTO.setItemOptions(options);
 
 		// When and Then
-		webTestClient.post().uri("/orderable/certificates")
-				.contentType(MediaType.APPLICATION_JSON)
-				.body(fromValue(newCertificateItemDTO))
-				.exchange()
-				.expectStatus().isBadRequest()
-				.expectBody()
-				.jsonPath("$.error").isEqualTo("Bad Request")
-				.jsonPath("$.errors[0].field").isEqualTo("quantity");
-
+		postBadCreateRequestAndExpectError(newCertificateItemDTO, "quantity: must be greater than or equal to 1");
 	}
 
 	@Test
@@ -141,15 +117,7 @@ class ItemsApiApplicationTests {
 		newCertificateItemDTO.setQuantity(5);
 
 		// When and Then
-		webTestClient.post().uri("/orderable/certificates")
-				.contentType(MediaType.APPLICATION_JSON)
-				.body(fromValue(newCertificateItemDTO))
-				.exchange()
-				.expectStatus().isBadRequest()
-				.expectBody()
-				.jsonPath("$.error").isEqualTo("Bad Request")
-				.jsonPath("$.errors[0].field").isEqualTo("itemCosts");
-
+		postBadCreateRequestAndExpectError(newCertificateItemDTO, "item_costs: must be null");
 	}
 
 	@Test
@@ -167,15 +135,7 @@ class ItemsApiApplicationTests {
 		newCertificateItemDTO.setQuantity(5);
 
 		// When and Then
-		webTestClient.post().uri("/orderable/certificates")
-				.contentType(MediaType.APPLICATION_JSON)
-				.body(fromValue(newCertificateItemDTO))
-				.exchange()
-				.expectStatus().isBadRequest()
-				.expectBody()
-				.jsonPath("$.error").isEqualTo("Bad Request")
-				.jsonPath("$.errors[0].field").isEqualTo("description");
-
+		postBadCreateRequestAndExpectError(newCertificateItemDTO, "description: must be null");
 	}
 
 
@@ -194,15 +154,7 @@ class ItemsApiApplicationTests {
 		newCertificateItemDTO.setQuantity(5);
 
 		// When and Then
-		webTestClient.post().uri("/orderable/certificates")
-				.contentType(MediaType.APPLICATION_JSON)
-				.body(fromValue(newCertificateItemDTO))
-				.exchange()
-				.expectStatus().isBadRequest()
-				.expectBody()
-				.jsonPath("$.error").isEqualTo("Bad Request")
-				.jsonPath("$.errors[0].field").isEqualTo("descriptionIdentifier");
-
+		postBadCreateRequestAndExpectError(newCertificateItemDTO, "description_identifier: must be null");
 	}
 
 	@Test
@@ -220,15 +172,24 @@ class ItemsApiApplicationTests {
 		newCertificateItemDTO.setQuantity(5);
 
 		// When and Then
+		postBadCreateRequestAndExpectError(newCertificateItemDTO, "description_values: must be null");
+	}
+
+	/**
+	 * Utility method that posts the create certificate item request, asserts a bad request status response and an
+	 * expected validation error message.
+	 * @param itemToCreate the DTO representing the certificate item to be requested
+	 * @param expectedError expected validation error message
+	 */
+	private void postBadCreateRequestAndExpectError(final CertificateItemDTO itemToCreate, final String expectedError) {
 		webTestClient.post().uri("/orderable/certificates")
 				.contentType(MediaType.APPLICATION_JSON)
-				.body(fromValue(newCertificateItemDTO))
+				.body(fromValue(itemToCreate))
 				.exchange()
 				.expectStatus().isBadRequest()
 				.expectBody()
-				.jsonPath("$.error").isEqualTo("Bad Request")
-				.jsonPath("$.errors[0].field").isEqualTo("descriptionValues");
-
+				.jsonPath("$.status").isEqualTo("BAD_REQUEST")
+				.jsonPath("$.errors[0]").isEqualTo(expectedError);
 	}
 
 }

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/ItemsApiApplicationTests.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/ItemsApiApplicationTests.java
@@ -28,6 +28,36 @@ class ItemsApiApplicationTests {
 		// No implementation required here to test that context loads.
 	}
 
+    @Test
+    @DisplayName("Create rejects missing company number")
+    void createCertificateItemRejectsMissingCompanyNumber() {
+
+        // Given
+        final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
+        final ItemCosts costs = new ItemCosts();
+        costs.setDiscountApplied("1");
+        costs.setIndividualItemCost("2");
+        costs.setPostageCost("3");
+        costs.setTotalCost("4");
+        newCertificateItemDTO.setItemCosts(costs);
+        final CertificateItemOptions options = new CertificateItemOptions();
+        options.setCertInc(true);
+        options.setCertShar(true);
+        newCertificateItemDTO.setItemOptions(options);
+        newCertificateItemDTO.setQuantity(5);
+
+        // When and Then
+        webTestClient.post().uri("/orderable/certificates")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(fromValue(newCertificateItemDTO))
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody()
+                .jsonPath("$.error").isEqualTo("Bad Request")
+                .jsonPath("$.errors[0].field").isEqualTo("companyNumber");
+
+    }
+
 	@Test
 	@DisplayName("Create does not reject missing item costs")
 	void createCertificateItemDoesNotRejectsMissingItemCosts() {

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/ItemsApiApplicationTests.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/ItemsApiApplicationTests.java
@@ -11,6 +11,8 @@ import uk.gov.companieshouse.items.orders.api.dto.CertificateItemDTO;
 import uk.gov.companieshouse.items.orders.api.model.CertificateItemOptions;
 import uk.gov.companieshouse.items.orders.api.model.ItemCosts;
 
+import java.util.HashMap;
+
 import static org.springframework.web.reactive.function.BodyInserters.fromValue;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -34,12 +36,6 @@ class ItemsApiApplicationTests {
 
         // Given
         final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
-        final ItemCosts costs = new ItemCosts();
-        costs.setDiscountApplied("1");
-        costs.setIndividualItemCost("2");
-        costs.setPostageCost("3");
-        costs.setTotalCost("4");
-        newCertificateItemDTO.setItemCosts(costs);
         final CertificateItemOptions options = new CertificateItemOptions();
         options.setCertInc(true);
         options.setCertShar(true);
@@ -60,7 +56,7 @@ class ItemsApiApplicationTests {
 
 	@Test
 	@DisplayName("Create does not reject missing item costs")
-	void createCertificateItemDoesNotRejectsMissingItemCosts() {
+	void createCertificateItemDoesNotRejectMissingItemCosts() {
 
 		// Given
 		final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
@@ -77,6 +73,7 @@ class ItemsApiApplicationTests {
 				.body(fromValue(newCertificateItemDTO))
 				.exchange()
 				.expectStatus().isCreated();
+
 	}
 
 	@Test
@@ -86,12 +83,6 @@ class ItemsApiApplicationTests {
 		// Given
 		final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
 		newCertificateItemDTO.setCompanyNumber("1234");
-		final ItemCosts costs = new ItemCosts();
-		costs.setDiscountApplied("1");
-		costs.setIndividualItemCost("2");
-		costs.setPostageCost("3");
-		costs.setTotalCost("4");
-		newCertificateItemDTO.setItemCosts(costs);
 		newCertificateItemDTO.setQuantity(5);
 
 		// When and Then
@@ -113,12 +104,6 @@ class ItemsApiApplicationTests {
 		// Given
 		final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
 		newCertificateItemDTO.setCompanyNumber("1234");
-		final ItemCosts costs = new ItemCosts();
-		costs.setDiscountApplied("1");
-		costs.setIndividualItemCost("2");
-		costs.setPostageCost("3");
-		costs.setTotalCost("4");
-		newCertificateItemDTO.setItemCosts(costs);
 		final CertificateItemOptions options = new CertificateItemOptions();
 		options.setCertInc(true);
 		options.setCertShar(true);
@@ -133,6 +118,116 @@ class ItemsApiApplicationTests {
 				.expectBody()
 				.jsonPath("$.error").isEqualTo("Bad Request")
 				.jsonPath("$.errors[0].field").isEqualTo("quantity");
+
+	}
+
+	@Test
+	@DisplayName("Create rejects read only item costs")
+	void createCertificateItemRejectsReadOnlyItemCosts() {
+
+		// Given
+		final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
+		newCertificateItemDTO.setCompanyNumber("1234");
+		final ItemCosts costs = new ItemCosts();
+		costs.setDiscountApplied("1");
+		costs.setIndividualItemCost("2");
+		costs.setPostageCost("3");
+		costs.setTotalCost("4");
+		newCertificateItemDTO.setItemCosts(costs);
+		final CertificateItemOptions options = new CertificateItemOptions();
+		options.setCertInc(true);
+		options.setCertShar(true);
+		newCertificateItemDTO.setItemOptions(options);
+		newCertificateItemDTO.setQuantity(5);
+
+		// When and Then
+		webTestClient.post().uri("/orderable/certificates")
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(fromValue(newCertificateItemDTO))
+				.exchange()
+				.expectStatus().isBadRequest()
+				.expectBody()
+				.jsonPath("$.error").isEqualTo("Bad Request")
+				.jsonPath("$.errors[0].field").isEqualTo("itemCosts");
+
+	}
+
+	@Test
+	@DisplayName("Create rejects read only description")
+	void createCertificateItemRejectsReadOnlyDescription() {
+
+		// Given
+		final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
+		newCertificateItemDTO.setCompanyNumber("1234");
+		newCertificateItemDTO.setDescription("description text");
+		final CertificateItemOptions options = new CertificateItemOptions();
+		options.setCertInc(true);
+		options.setCertShar(true);
+		newCertificateItemDTO.setItemOptions(options);
+		newCertificateItemDTO.setQuantity(5);
+
+		// When and Then
+		webTestClient.post().uri("/orderable/certificates")
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(fromValue(newCertificateItemDTO))
+				.exchange()
+				.expectStatus().isBadRequest()
+				.expectBody()
+				.jsonPath("$.error").isEqualTo("Bad Request")
+				.jsonPath("$.errors[0].field").isEqualTo("description");
+
+	}
+
+
+	@Test
+	@DisplayName("Create rejects read only description identifier")
+	void createCertificateItemRejectsReadOnlyDescriptionIdentifier() {
+
+		// Given
+		final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
+		newCertificateItemDTO.setCompanyNumber("1234");
+		newCertificateItemDTO.setDescriptionIdentifier("description identifier text");
+		final CertificateItemOptions options = new CertificateItemOptions();
+		options.setCertInc(true);
+		options.setCertShar(true);
+		newCertificateItemDTO.setItemOptions(options);
+		newCertificateItemDTO.setQuantity(5);
+
+		// When and Then
+		webTestClient.post().uri("/orderable/certificates")
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(fromValue(newCertificateItemDTO))
+				.exchange()
+				.expectStatus().isBadRequest()
+				.expectBody()
+				.jsonPath("$.error").isEqualTo("Bad Request")
+				.jsonPath("$.errors[0].field").isEqualTo("descriptionIdentifier");
+
+	}
+
+	@Test
+	@DisplayName("Create rejects read only description values")
+	void createCertificateItemRejectsReadOnlyDescriptionValues() {
+
+		// Given
+		final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
+		newCertificateItemDTO.setCompanyNumber("1234");
+		newCertificateItemDTO.setDescriptionValues(new HashMap<>());
+		final CertificateItemOptions options = new CertificateItemOptions();
+		options.setCertInc(true);
+		options.setCertShar(true);
+		newCertificateItemDTO.setItemOptions(options);
+		newCertificateItemDTO.setQuantity(5);
+
+		// When and Then
+		webTestClient.post().uri("/orderable/certificates")
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(fromValue(newCertificateItemDTO))
+				.exchange()
+				.expectStatus().isBadRequest()
+				.expectBody()
+				.jsonPath("$.error").isEqualTo("Bad Request")
+				.jsonPath("$.errors[0].field").isEqualTo("descriptionValues");
 
 	}
 

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/ItemsApiApplicationTests.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/ItemsApiApplicationTests.java
@@ -29,8 +29,8 @@ class ItemsApiApplicationTests {
 	}
 
 	@Test
-	@DisplayName("Create rejects missing item costs")
-	void createCertificateItemRejectsMissingItemCosts() {
+	@DisplayName("Create does not reject missing item costs")
+	void createCertificateItemDoesNotRejectsMissingItemCosts() {
 
 		// Given
 		final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
@@ -46,10 +46,7 @@ class ItemsApiApplicationTests {
 				.contentType(MediaType.APPLICATION_JSON)
 				.body(fromValue(newCertificateItemDTO))
 				.exchange()
-				.expectStatus().isBadRequest()
-				.expectBody()
-				.jsonPath("$.error").isEqualTo("Bad Request")
-				.jsonPath("$.errors[0].field").isEqualTo("itemCosts");
+				.expectStatus().isCreated();
 	}
 
 	@Test

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/ItemsApiApplicationTests.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/ItemsApiApplicationTests.java
@@ -1,14 +1,112 @@
 package uk.gov.companieshouse.items.orders.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import uk.gov.companieshouse.items.orders.api.dto.CertificateItemDTO;
+import uk.gov.companieshouse.items.orders.api.model.CertificateItemOptions;
+import uk.gov.companieshouse.items.orders.api.model.ItemCosts;
 
-@SpringBootTest
+import static org.springframework.web.reactive.function.BodyInserters.fromValue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class ItemsApiApplicationTests {
 
+	@Autowired
+	private WebTestClient webTestClient;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
 	@Test
+	@DisplayName("Application context loads successfully")
 	void contextLoads() {
 		// No implementation required here to test that context loads.
+	}
+
+	@Test
+	@DisplayName("Create rejects missing item costs")
+	void createCertificateItemRejectsMissingItemCosts() {
+
+		// Given
+		final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
+		newCertificateItemDTO.setCompanyNumber("1234");
+		final CertificateItemOptions options = new CertificateItemOptions();
+		options.setCertInc(true);
+		options.setCertShar(true);
+		newCertificateItemDTO.setItemOptions(options);
+		newCertificateItemDTO.setQuantity(5);
+
+		// When and Then
+		webTestClient.post().uri("/orderable/certificates")
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(fromValue(newCertificateItemDTO))
+				.exchange()
+				.expectStatus().isBadRequest()
+				.expectBody()
+				.jsonPath("$.error").isEqualTo("Bad Request")
+				.jsonPath("$.errors[0].field").isEqualTo("itemCosts");
+	}
+
+	@Test
+	@DisplayName("Create rejects missing item options")
+	void createCertificateItemRejectsMissingItemOptions() {
+
+		// Given
+		final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
+		newCertificateItemDTO.setCompanyNumber("1234");
+		final ItemCosts costs = new ItemCosts();
+		costs.setDiscountApplied("1");
+		costs.setIndividualItemCost("2");
+		costs.setPostageCost("3");
+		costs.setTotalCost("4");
+		newCertificateItemDTO.setItemCosts(costs);
+		newCertificateItemDTO.setQuantity(5);
+
+		// When and Then
+		webTestClient.post().uri("/orderable/certificates")
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(fromValue(newCertificateItemDTO))
+				.exchange()
+				.expectStatus().isBadRequest()
+				.expectBody()
+				.jsonPath("$.error").isEqualTo("Bad Request")
+				.jsonPath("$.errors[0].field").isEqualTo("itemOptions");
+
+	}
+
+	@Test
+	@DisplayName("Create rejects missing quantity")
+	void createCertificateItemRejectsMissingQuantity() {
+
+		// Given
+		final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
+		newCertificateItemDTO.setCompanyNumber("1234");
+		final ItemCosts costs = new ItemCosts();
+		costs.setDiscountApplied("1");
+		costs.setIndividualItemCost("2");
+		costs.setPostageCost("3");
+		costs.setTotalCost("4");
+		newCertificateItemDTO.setItemCosts(costs);
+		final CertificateItemOptions options = new CertificateItemOptions();
+		options.setCertInc(true);
+		options.setCertShar(true);
+		newCertificateItemDTO.setItemOptions(options);
+
+		// When and Then
+		webTestClient.post().uri("/orderable/certificates")
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(fromValue(newCertificateItemDTO))
+				.exchange()
+				.expectStatus().isBadRequest()
+				.expectBody()
+				.jsonPath("$.error").isEqualTo("Bad Request")
+				.jsonPath("$.errors[0].field").isEqualTo("quantity");
+
 	}
 
 }

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerUnitTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
@@ -21,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Unit/integration tests the {@link CertificateItemsController} class.
  */
 @AutoConfigureMockMvc
-@WebMvcTest
+@SpringBootTest
 class CertificateItemsControllerUnitTest {
 
     @Autowired

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerUnitTest.java
@@ -31,7 +31,7 @@ class CertificateItemsControllerUnitTest {
     private ObjectMapper objectMapper;
 
     @Test
-    @DisplayName("Creates certificate item creation")
+    @DisplayName("Create creates certificate item")
     void createCertificateItemCreatesCertificateItem() throws Exception {
 
         // Given
@@ -72,75 +72,6 @@ class CertificateItemsControllerUnitTest {
 
         // Then
         // TODO PCI-324 Verify can retrieve equivalent entity
-
-    }
-
-    @Test
-    @DisplayName("Create rejects missing item costs")
-    void createCertificateItemRejectsMissingItemCosts() throws Exception {
-
-        // Given
-        final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
-        newCertificateItemDTO.setCompanyNumber("1234");
-        final CertificateItemOptions options = new CertificateItemOptions();
-        options.setCertInc(true);
-        options.setCertShar(true);
-        newCertificateItemDTO.setItemOptions(options);
-        newCertificateItemDTO.setQuantity(5);
-
-        // When and Then
-        mockMvc.perform(post("/certificates")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(newCertificateItemDTO)))
-                .andExpect(status().isBadRequest()).andDo(MockMvcResultHandlers.print());
-    }
-
-    @Test
-    @DisplayName("Create rejects missing item options")
-    void createCertificateItemRejectsMissingItemOptions() throws Exception {
-
-        // Given
-        final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
-        newCertificateItemDTO.setCompanyNumber("1234");
-        final ItemCosts costs = new ItemCosts();
-        costs.setDiscountApplied("1");
-        costs.setIndividualItemCost("2");
-        costs.setPostageCost("3");
-        costs.setTotalCost("4");
-        newCertificateItemDTO.setItemCosts(costs);
-        newCertificateItemDTO.setQuantity(5);
-
-        // When and Then
-        mockMvc.perform(post("/certificates")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(newCertificateItemDTO)))
-                .andExpect(status().isBadRequest()).andDo(MockMvcResultHandlers.print());
-
-    }
-
-    @Test
-    @DisplayName("Create rejects missing quantity")
-    void createCertificateItemRejectsMissingQuantity() throws Exception {
-
-        // Given
-        final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
-        newCertificateItemDTO.setCompanyNumber("1234");
-        final ItemCosts costs = new ItemCosts();
-        costs.setDiscountApplied("1");
-        costs.setIndividualItemCost("2");
-        costs.setPostageCost("3");
-        costs.setTotalCost("4");
-        newCertificateItemDTO.setItemCosts(costs);
-        final CertificateItemOptions options = new CertificateItemOptions();
-        options.setCertInc(true);
-        options.setCertShar(true);
-        newCertificateItemDTO.setItemOptions(options);
-
-        // When and Then
-        mockMvc.perform(post("/certificates")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(newCertificateItemDTO)))
-                .andExpect(status().isBadRequest()).andDo(MockMvcResultHandlers.print());
 
     }
 

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerUnitTest.java
@@ -37,12 +37,6 @@ class CertificateItemsControllerUnitTest {
         // Given
         final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
         newCertificateItemDTO.setCompanyNumber("1234");
-        final ItemCosts costs = new ItemCosts();
-        costs.setDiscountApplied("1");
-        costs.setIndividualItemCost("2");
-        costs.setPostageCost("3");
-        costs.setTotalCost("4");
-        newCertificateItemDTO.setItemCosts(costs);
         final CertificateItemOptions options = new CertificateItemOptions();
         options.setCertInc(true);
         options.setCertShar(true);
@@ -54,6 +48,11 @@ class CertificateItemsControllerUnitTest {
         createdCertificateItemDTO.setCompanyNumber(newCertificateItemDTO.getCompanyNumber());
         createdCertificateItemDTO.setKind("certificate");
         createdCertificateItemDTO.setDescriptionIdentifier("certificate");
+        final ItemCosts costs = new ItemCosts();
+        costs.setDiscountApplied("1");
+        costs.setIndividualItemCost("2");
+        costs.setPostageCost("3");
+        costs.setTotalCost("4");
         createdCertificateItemDTO.setItemCosts(costs);
         createdCertificateItemDTO.setItemOptions(options);
         createdCertificateItemDTO.setPostalDelivery(true);

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerUnitTest.java
@@ -8,14 +8,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import uk.gov.companieshouse.items.orders.api.dto.CertificateItemDTO;
 import uk.gov.companieshouse.items.orders.api.model.CertificateItemOptions;
 import uk.gov.companieshouse.items.orders.api.model.ItemCosts;
 
+import static org.hamcrest.core.Is.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import static org.hamcrest.core.Is.is;
 
 /**
  * Unit/integration tests the {@link CertificateItemsController} class.
@@ -31,7 +31,7 @@ class CertificateItemsControllerUnitTest {
     private ObjectMapper objectMapper;
 
     @Test
-    @DisplayName("Test certificate item creation")
+    @DisplayName("Creates certificate item creation")
     void createCertificateItemCreatesCertificateItem() throws Exception {
 
         // Given
@@ -47,6 +47,7 @@ class CertificateItemsControllerUnitTest {
         options.setCertInc(true);
         options.setCertShar(true);
         newCertificateItemDTO.setItemOptions(options);
+        newCertificateItemDTO.setQuantity(5);
 
         final CertificateItemDTO createdCertificateItemDTO = new CertificateItemDTO();
         createdCertificateItemDTO.setId("CHS1");
@@ -56,6 +57,7 @@ class CertificateItemsControllerUnitTest {
         createdCertificateItemDTO.setItemCosts(costs);
         createdCertificateItemDTO.setItemOptions(options);
         createdCertificateItemDTO.setPostalDelivery(true);
+        createdCertificateItemDTO.setQuantity(5);
 
         // When and Then
         mockMvc.perform(post("/certificates")
@@ -66,10 +68,79 @@ class CertificateItemsControllerUnitTest {
                 .andExpect(jsonPath("$.item_options.cert_inc", is(true)))
                 .andExpect(jsonPath("$.item_options.cert_shar", is(true)))
                 .andExpect(jsonPath("$.item_options.cert_dissliq", is(false)))
-                .andExpect(jsonPath("$.postal_delivery", is(true)));
+                .andExpect(jsonPath("$.postal_delivery", is(true))).andDo(MockMvcResultHandlers.print());
 
         // Then
         // TODO PCI-324 Verify can retrieve equivalent entity
+
+    }
+
+    @Test
+    @DisplayName("Create rejects missing item costs")
+    void createCertificateItemRejectsMissingItemCosts() throws Exception {
+
+        // Given
+        final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
+        newCertificateItemDTO.setCompanyNumber("1234");
+        final CertificateItemOptions options = new CertificateItemOptions();
+        options.setCertInc(true);
+        options.setCertShar(true);
+        newCertificateItemDTO.setItemOptions(options);
+        newCertificateItemDTO.setQuantity(5);
+
+        // When and Then
+        mockMvc.perform(post("/certificates")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(newCertificateItemDTO)))
+                .andExpect(status().isBadRequest()).andDo(MockMvcResultHandlers.print());
+    }
+
+    @Test
+    @DisplayName("Create rejects missing item options")
+    void createCertificateItemRejectsMissingItemOptions() throws Exception {
+
+        // Given
+        final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
+        newCertificateItemDTO.setCompanyNumber("1234");
+        final ItemCosts costs = new ItemCosts();
+        costs.setDiscountApplied("1");
+        costs.setIndividualItemCost("2");
+        costs.setPostageCost("3");
+        costs.setTotalCost("4");
+        newCertificateItemDTO.setItemCosts(costs);
+        newCertificateItemDTO.setQuantity(5);
+
+        // When and Then
+        mockMvc.perform(post("/certificates")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(newCertificateItemDTO)))
+                .andExpect(status().isBadRequest()).andDo(MockMvcResultHandlers.print());
+
+    }
+
+    @Test
+    @DisplayName("Create rejects missing quantity")
+    void createCertificateItemRejectsMissingQuantity() throws Exception {
+
+        // Given
+        final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
+        newCertificateItemDTO.setCompanyNumber("1234");
+        final ItemCosts costs = new ItemCosts();
+        costs.setDiscountApplied("1");
+        costs.setIndividualItemCost("2");
+        costs.setPostageCost("3");
+        costs.setTotalCost("4");
+        newCertificateItemDTO.setItemCosts(costs);
+        final CertificateItemOptions options = new CertificateItemOptions();
+        options.setCertInc(true);
+        options.setCertShar(true);
+        newCertificateItemDTO.setItemOptions(options);
+
+        // When and Then
+        mockMvc.perform(post("/certificates")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(newCertificateItemDTO)))
+                .andExpect(status().isBadRequest()).andDo(MockMvcResultHandlers.print());
 
     }
 

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/util/FieldNameConverterUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/util/FieldNameConverterUnitTest.java
@@ -1,0 +1,26 @@
+package uk.gov.companieshouse.items.orders.api.util;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Unit tests the {@link FieldNameConverter} class.
+ */
+@SpringBootTest
+class FieldNameConverterUnitTest {
+
+    @Autowired
+    private FieldNameConverter converterUnderTest;
+
+    @Test
+    void toSnakeCaseWorksAsExpected() {
+        assertThat(converterUnderTest.toSnakeCase("itemCosts"), is("item_costs"));
+        assertThat(converterUnderTest.toSnakeCase("item"), is("item"));
+        // Does not work for more than two words!
+        assertThat(converterUnderTest.toSnakeCase("certIncConLast"), is("certIncCon_last"));
+    }
+}

--- a/src/test/postman/Items_API.postman_collection.json
+++ b/src/test/postman/Items_API.postman_collection.json
@@ -310,6 +310,42 @@
 										}
 									},
 									"response": []
+								},
+								{
+									"name": "Create certificate item read only id",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"id\": \"1\",\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "http://chs-dev:10020/orderable/certificates",
+											"protocol": "http",
+											"host": [
+												"chs-dev"
+											],
+											"port": "10020",
+											"path": [
+												"orderable",
+												"certificates"
+											]
+										}
+									},
+									"response": []
 								}
 							],
 							"description": "Test what happen when requests are made containing values for read only attributes.",

--- a/src/test/postman/Items_API.postman_collection.json
+++ b/src/test/postman/Items_API.postman_collection.json
@@ -7,184 +7,357 @@
 	},
 	"item": [
 		{
-			"name": "Create item",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"name": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n\t\"company_number\": \"00006400\",\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+			"name": "Certificates API",
+			"item": [
+				{
+					"name": "Create certificate item",
+					"item": [
+						{
+							"name": "Missing attributes",
+							"item": [
+								{
+									"name": "Create certificate item missing company number",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "http://chs-dev:10020/orderable/certificates",
+											"protocol": "http",
+											"host": [
+												"chs-dev"
+											],
+											"port": "10020",
+											"path": [
+												"orderable",
+												"certificates"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create certificate item missing quantity",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"company_number\": \"00006400\",\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "http://chs-dev:10020/orderable/certificates",
+											"protocol": "http",
+											"host": [
+												"chs-dev"
+											],
+											"port": "10020",
+											"path": [
+												"orderable",
+												"certificates"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create certificate item missing item costs",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"company_number\": \"000064000\",\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "http://chs-dev:10020/orderable/certificates",
+											"protocol": "http",
+											"host": [
+												"chs-dev"
+											],
+											"port": "10020",
+											"path": [
+												"orderable",
+												"certificates"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create certificate item missing item options",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"quantity\": 3\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "http://chs-dev:10020/orderable/certificates",
+											"protocol": "http",
+											"host": [
+												"chs-dev"
+											],
+											"port": "10020",
+											"path": [
+												"orderable",
+												"certificates"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"description": "Test what happens when attributes are missing from request payloads.",
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Read only attributes",
+							"item": [
+								{
+									"name": "Create certificate item read only item costs",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"item_costs\": {},\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "http://chs-dev:10020/orderable/certificates",
+											"protocol": "http",
+											"host": [
+												"chs-dev"
+											],
+											"port": "10020",
+											"path": [
+												"orderable",
+												"certificates"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create certificate item read only description",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"description\": \"description text\",\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "http://chs-dev:10020/orderable/certificates",
+											"protocol": "http",
+											"host": [
+												"chs-dev"
+											],
+											"port": "10020",
+											"path": [
+												"orderable",
+												"certificates"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create certificate item read only description identifier",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"description_identifier\": \"description identifier text\",\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "http://chs-dev:10020/orderable/certificates",
+											"protocol": "http",
+											"host": [
+												"chs-dev"
+											],
+											"port": "10020",
+											"path": [
+												"orderable",
+												"certificates"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create certificate item read only description values",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"description_values\": {},\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "http://chs-dev:10020/orderable/certificates",
+											"protocol": "http",
+											"host": [
+												"chs-dev"
+											],
+											"port": "10020",
+											"path": [
+												"orderable",
+												"certificates"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"description": "Test what happen when requests are made containing values for read only attributes.",
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Create certificate item",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"company_number\": \"00006400\",\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://chs-dev:10020/orderable/certificates",
+									"protocol": "http",
+									"host": [
+										"chs-dev"
+									],
+									"port": "10020",
+									"path": [
+										"orderable",
+										"certificates"
+									]
+								}
+							},
+							"response": []
 						}
-					}
-				},
-				"url": {
-					"raw": "http://chs-dev:10020/orderable/certificates",
-					"protocol": "http",
-					"host": [
-						"chs-dev"
 					],
-					"port": "10020",
-					"path": [
-						"orderable",
-						"certificates"
-					]
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
 				}
-			},
-			"response": []
-		},
-		{
-			"name": "Create item missing company number",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"name": "Content-Type",
-						"type": "text",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://chs-dev:10020/orderable/certificates",
-					"protocol": "http",
-					"host": [
-						"chs-dev"
-					],
-					"port": "10020",
-					"path": [
-						"orderable",
-						"certificates"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Create item missing quantity",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"name": "Content-Type",
-						"type": "text",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n\t\"company_number\": \"00006400\",\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    }\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://chs-dev:10020/orderable/certificates",
-					"protocol": "http",
-					"host": [
-						"chs-dev"
-					],
-					"port": "10020",
-					"path": [
-						"orderable",
-						"certificates"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Create item missing item costs",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"name": "Content-Type",
-						"type": "text",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n\t\"company_number\": \"000064000\",\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://chs-dev:10020/orderable/certificates",
-					"protocol": "http",
-					"host": [
-						"chs-dev"
-					],
-					"port": "10020",
-					"path": [
-						"orderable",
-						"certificates"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Create item missing item options",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"name": "Content-Type",
-						"type": "text",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"quantity\": 3\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://chs-dev:10020/orderable/certificates",
-					"protocol": "http",
-					"host": [
-						"chs-dev"
-					],
-					"port": "10020",
-					"path": [
-						"orderable",
-						"certificates"
-					]
-				}
-			},
-			"response": []
+			],
+			"protocolProfileBehavior": {}
 		}
 	]
 }

--- a/src/test/postman/Items_API.postman_collection.json
+++ b/src/test/postman/Items_API.postman_collection.json
@@ -20,7 +20,115 @@
 				],
 				"body": {
 					"mode": "raw",
+					"raw": "{\n\t\"company_number\": \"000064000\",\n\t\"item_costs\": {},\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://chs-dev:10020/orderable/certificates",
+					"protocol": "http",
+					"host": [
+						"chs-dev"
+					],
+					"port": "10020",
+					"path": [
+						"orderable",
+						"certificates"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Create item missing quantity",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"company_number\": \"000064000\",\n\t\"item_costs\": {},\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://chs-dev:10020/orderable/certificates",
+					"protocol": "http",
+					"host": [
+						"chs-dev"
+					],
+					"port": "10020",
+					"path": [
+						"orderable",
+						"certificates"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Create item missing item costs",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
 					"raw": "{\n\t\"company_number\": \"000064000\",\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://chs-dev:10020/orderable/certificates",
+					"protocol": "http",
+					"host": [
+						"chs-dev"
+					],
+					"port": "10020",
+					"path": [
+						"orderable",
+						"certificates"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Create item missing item options",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"company_number\": \"000064000\",\n\t\"item_costs\": {},\n\t\"quantity\": 3\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/src/test/postman/Items_API.postman_collection.json
+++ b/src/test/postman/Items_API.postman_collection.json
@@ -20,7 +20,43 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"company_number\": \"000064000\",\n\t\"item_costs\": {},\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+					"raw": "{\n\t\"company_number\": \"00006400\",\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://chs-dev:10020/orderable/certificates",
+					"protocol": "http",
+					"host": [
+						"chs-dev"
+					],
+					"port": "10020",
+					"path": [
+						"orderable",
+						"certificates"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Create item missing company number",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -56,7 +92,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"company_number\": \"000064000\",\n\t\"item_costs\": {},\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    }\n}",
+					"raw": "{\n\t\"company_number\": \"00006400\",\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    }\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -128,7 +164,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"company_number\": \"000064000\",\n\t\"item_costs\": {},\n\t\"quantity\": 3\n}",
+					"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"quantity\": 3\n}",
 					"options": {
 						"raw": {
 							"language": "json"


### PR DESCRIPTION
* Implements basic field value validation for required and read only fields in the payload of certificate item requests based on https://developer-specs.kermit.aws.chdev.org/order-company-products/reference/certificates.