### PR TITLE
PCI-589: Correct update response to align with API spec

### DIFF
--- a/src/main/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsController.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsController.java
@@ -112,9 +112,9 @@ public class CertificateItemsController {
 
         final CertificateItem savedItem = service.saveCertificateItem(patchedItem);
 
-        trace("Certificate item updated to " + savedItem, requestId);
+        trace("EXITING updateCertificateItem() with " + savedItem, requestId);
 
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok().body(savedItem);
     }
 
     /**

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerIntegrationTest.java
@@ -215,7 +215,7 @@ class CertificateItemsControllerIntegrationTest {
                 .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
                 .contentType(PatchMediaType.APPLICATION_MERGE_PATCH)
                 .content(objectMapper.writeValueAsString(itemUpdate)))
-                .andExpect(status().isNoContent())
+                .andExpect(status().isOk())
                 .andDo(MockMvcResultHandlers.print());
 
         // Then
@@ -307,7 +307,7 @@ class CertificateItemsControllerIntegrationTest {
                 .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
                 .contentType(PatchMediaType.APPLICATION_MERGE_PATCH)
                 .content(objectMapper.writeValueAsString(itemUpdate)))
-                .andExpect(status().isNoContent())
+                .andExpect(status().isOk())
                 .andDo(MockMvcResultHandlers.print());
     }
 

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerIntegrationTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import uk.gov.companieshouse.items.orders.api.dto.CertificateItemDTO;
 import uk.gov.companieshouse.items.orders.api.dto.PatchValidationCertificateItemDTO;
@@ -211,7 +212,7 @@ class CertificateItemsControllerIntegrationTest {
         itemUpdate.setItemOptions(options);
 
         // When and then
-        mockMvc.perform(patch("/certificates/" + EXPECTED_ITEM_ID)
+        final ResultActions response = mockMvc.perform(patch("/certificates/" + EXPECTED_ITEM_ID)
                 .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
                 .contentType(PatchMediaType.APPLICATION_MERGE_PATCH)
                 .content(objectMapper.writeValueAsString(itemUpdate)))
@@ -224,6 +225,8 @@ class CertificateItemsControllerIntegrationTest {
         assertThat(retrievedCertificateItem.get().getId(), is(EXPECTED_ITEM_ID));
         assertThat(retrievedCertificateItem.get().getQuantity(), is(UPDATED_QUANTITY));
         assertThat(retrievedCertificateItem.get().getItemOptions().isCertInc(), is(UPDATED_CERT_INC));
+
+        response.andExpect(content().json(objectMapper.writeValueAsString(retrievedCertificateItem)));
     }
 
     @Test
@@ -303,12 +306,21 @@ class CertificateItemsControllerIntegrationTest {
         final TestDTO itemUpdate = new TestDTO("Unknown field value");
 
         // When and then
-        mockMvc.perform(patch("/certificates/" + EXPECTED_ITEM_ID)
+        final ResultActions response = mockMvc.perform(patch("/certificates/" + EXPECTED_ITEM_ID)
                 .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
                 .contentType(PatchMediaType.APPLICATION_MERGE_PATCH)
                 .content(objectMapper.writeValueAsString(itemUpdate)))
                 .andExpect(status().isOk())
                 .andDo(MockMvcResultHandlers.print());
+
+        // Then
+        final Optional<CertificateItem> retrievedCertificateItem = repository.findById(EXPECTED_ITEM_ID);
+        assertThat(retrievedCertificateItem.isPresent(), is(true));
+        assertThat(retrievedCertificateItem.get().getId(), is(EXPECTED_ITEM_ID));
+        assertThat(retrievedCertificateItem.get().getQuantity(), is(QUANTITY));
+        assertThat(retrievedCertificateItem.get().getItemOptions().isCertInc(), is(ORIGINAL_CERT_INC));
+
+        response.andExpect(content().json(objectMapper.writeValueAsString(retrievedCertificateItem)));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificatesItemControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificatesItemControllerTest.java
@@ -55,7 +55,7 @@ public class CertificatesItemControllerTest {
 
     @Test
     @DisplayName("Update request updates successfully")
-    void updateUpdatesSuccessfully() throws IOException {
+    void updateUpdatesSuccessfully() {
         // Given
         when(service.getCertificateItemById(ITEM_ID)).thenReturn(Optional.of(item));
 
@@ -64,7 +64,7 @@ public class CertificatesItemControllerTest {
                 controllerUnderTest.updateCertificateItem(patch, ITEM_ID, TOKEN_REQUEST_ID_VALUE);
 
         // Then
-        assertThat(response.getStatusCode(), is(HttpStatus.NO_CONTENT));
+        assertThat(response.getStatusCode(), is(HttpStatus.OK));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificatesItemControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificatesItemControllerTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.is;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.items.orders.api.util.TestConstants.TOKEN_REQUEST_ID_VALUE;
 
@@ -58,6 +59,8 @@ public class CertificatesItemControllerTest {
     void updateUpdatesSuccessfully() {
         // Given
         when(service.getCertificateItemById(ITEM_ID)).thenReturn(Optional.of(item));
+        when(merger.mergePatch(patch, item, CertificateItem.class)).thenReturn(item);
+        when(service.saveCertificateItem(item)).thenReturn(item);
 
         // When
         final ResponseEntity<Object> response =
@@ -65,6 +68,7 @@ public class CertificatesItemControllerTest {
 
         // Then
         assertThat(response.getStatusCode(), is(HttpStatus.OK));
+        assertThat(response.getBody(), is(item));
     }
 
     @Test


### PR DESCRIPTION
* The response status for a successful update is now `200 OK` rather than `204 No Content`, and the response body now contains the updated item.  