### PR TITLE
PCI-668: Add missing top level fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 		<javax.json-api.version>1.1.4</javax.json-api.version>
 		<guava.version>28.1-jre</guava.version>
 		<snakeyaml.version>1.25</snakeyaml.version>
+		<start-class>uk.gov.companieshouse.items.orders.api.ItemsApiApplication</start-class>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<structured-logging.version>1.9.0</structured-logging.version>
+		<api-helper-java.version>1.1.0-rc1</api-helper-java.version>
 		<commons.lang.version>2.6</commons.lang.version>
 		<commons.beanutils.version>1.9.4</commons.beanutils.version>
 		<gson.version>2.8.0</gson.version>
@@ -50,6 +51,12 @@
 			<groupId>uk.gov.companieshouse</groupId>
 			<artifactId>structured-logging</artifactId>
 			<version>${structured-logging.version}</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>uk.gov.companieshouse</groupId>
+			<artifactId>api-helper-java</artifactId>
+			<version>${api-helper-java.version}</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/dto/CertificateItemDTO.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/dto/CertificateItemDTO.java
@@ -18,6 +18,10 @@ public class CertificateItemDTO extends ItemDTO {
     private CertificateItemOptions itemOptions;
 
     @NotNull
+    @JsonProperty("company_name")
+    private String companyName;
+
+    @NotNull
     @JsonProperty("company_number")
     private String companyNumber;
 
@@ -30,6 +34,14 @@ public class CertificateItemDTO extends ItemDTO {
 
     public void setItemOptions(CertificateItemOptions itemOptions) {
         this.itemOptions = itemOptions;
+    }
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
     }
 
     public String getCompanyNumber() {

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/dto/CertificateItemDTO.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/dto/CertificateItemDTO.java
@@ -36,28 +36,28 @@ public class CertificateItemDTO extends ItemDTO {
         this.itemOptions = itemOptions;
     }
 
-    public String getCompanyName() {
-        return companyName;
-    }
-
     public void setCompanyName(String companyName) {
         this.companyName = companyName;
     }
 
-    public String getCompanyNumber() {
-        return companyNumber;
+    public String getCompanyName() {
+        return companyName;
     }
 
     public void setCompanyNumber(String companyNumber) {
         this.companyNumber = companyNumber;
     }
 
-    public String getCustomerReference() {
-        return customerReference;
+    public String getCompanyNumber() {
+        return companyNumber;
     }
 
     public void setCustomerReference(String customerReference) {
         this.customerReference = customerReference;
+    }
+
+    public String getCustomerReference() {
+        return customerReference;
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/dto/CertificateItemDTO.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/dto/CertificateItemDTO.java
@@ -21,6 +21,9 @@ public class CertificateItemDTO extends ItemDTO {
     @JsonProperty("company_number")
     private String companyNumber;
 
+    @JsonProperty("customer_reference")
+    private String customerReference;
+
     public CertificateItemOptions getItemOptions() {
         return itemOptions;
     }
@@ -35,6 +38,14 @@ public class CertificateItemDTO extends ItemDTO {
 
     public void setCompanyNumber(String companyNumber) {
         this.companyNumber = companyNumber;
+    }
+
+    public String getCustomerReference() {
+        return customerReference;
+    }
+
+    public void setCustomerReference(String customerReference) {
+        this.customerReference = customerReference;
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/dto/ItemDTO.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/dto/ItemDTO.java
@@ -15,6 +15,10 @@ public class ItemDTO extends AbstractItemDTO {
     @JsonProperty("item_costs")
     private ItemCosts itemCosts;
 
+    @Null
+    @JsonProperty("etag")
+    private String etag;
+
     @JsonProperty("kind")
     private String kind;
 
@@ -34,6 +38,14 @@ public class ItemDTO extends AbstractItemDTO {
 
     public void setItemCosts(ItemCosts itemCosts) {
         this.itemCosts = itemCosts;
+    }
+
+    public String getEtag() {
+        return etag;
+    }
+
+    public void setEtag(String etag) {
+        this.etag = etag;
     }
 
     public String getKind() {

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/dto/PatchValidationCertificateItemDTO.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/dto/PatchValidationCertificateItemDTO.java
@@ -30,6 +30,10 @@ public class PatchValidationCertificateItemDTO extends AbstractItemDTO {
     private ItemCosts itemCosts;
 
     @Null
+    @JsonProperty("etag")
+    private String etag;
+
+    @Null
     @JsonProperty("kind")
     private String kind;
 
@@ -72,6 +76,10 @@ public class PatchValidationCertificateItemDTO extends AbstractItemDTO {
 
     public void setItemCosts(ItemCosts itemCosts) {
         this.itemCosts = itemCosts;
+    }
+
+    public void setEtag(String etag) {
+        this.etag = etag;
     }
 
     public void setKind(String kind) {

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/dto/PatchValidationCertificateItemDTO.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/dto/PatchValidationCertificateItemDTO.java
@@ -19,6 +19,9 @@ public class PatchValidationCertificateItemDTO extends AbstractItemDTO {
     @JsonProperty("company_number")
     private String companyNumber;
 
+    @JsonProperty("customer_reference")
+    private String customerReference;
+
     @Null
     @JsonProperty("item_costs")
     private ItemCosts itemCosts;
@@ -54,6 +57,10 @@ public class PatchValidationCertificateItemDTO extends AbstractItemDTO {
 
     public void setCompanyNumber(String companyNumber) {
         this.companyNumber = companyNumber;
+    }
+
+    public void setCustomerReference(String customerReference) {
+        this.customerReference = customerReference;
     }
 
     public void setItemCosts(ItemCosts itemCosts) {

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/dto/PatchValidationCertificateItemDTO.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/dto/PatchValidationCertificateItemDTO.java
@@ -16,6 +16,9 @@ public class PatchValidationCertificateItemDTO extends AbstractItemDTO {
     @JsonProperty("item_options")
     private CertificateItemOptions itemOptions;
 
+    @JsonProperty("company_name")
+    private String companyName;
+
     @JsonProperty("company_number")
     private String companyNumber;
 
@@ -53,6 +56,10 @@ public class PatchValidationCertificateItemDTO extends AbstractItemDTO {
 
     public void setItemOptions(CertificateItemOptions itemOptions) {
         this.itemOptions = itemOptions;
+    }
+
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
     }
 
     public void setCompanyNumber(String companyNumber) {

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/model/Item.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/model/Item.java
@@ -123,6 +123,14 @@ public class Item {
         data.setItemOptions(itemOptions);
     }
 
+    public String getEtag() {
+        return data.getEtag();
+    }
+
+    public void setEtag(String etag) {
+        data.setEtag(etag);
+    }
+
     public String getKind() {
         return data.getKind();
     }

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/model/Item.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/model/Item.java
@@ -67,6 +67,14 @@ public class Item {
         data.setCompanyNumber(companyNumber);
     }
 
+    public String getCustomerReference() {
+        return data.getCustomerReference();
+    }
+
+    public void setCustomerReference(String companyReference) {
+        data.setCustomerReference(companyReference);
+    }
+
     public String getDescription() {
         return data.getDescription();
     }

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/model/Item.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/model/Item.java
@@ -59,6 +59,14 @@ public class Item {
         this.data = data;
     }
 
+    public String getCompanyName() {
+        return data.getCompanyName();
+    }
+
+    public void setCompanyName(String companyName) {
+        data.setCompanyName(companyName);
+    }
+
     public String getCompanyNumber() {
         return data.getCompanyNumber();
     }

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/model/ItemData.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/model/ItemData.java
@@ -19,6 +19,8 @@ public class ItemData {
 
     private String companyNumber;
 
+    private String customerReference;
+
     private String description;
 
     private String descriptionIdentifier;
@@ -49,6 +51,14 @@ public class ItemData {
 
     public void setCompanyNumber(String companyNumber) {
         this.companyNumber = companyNumber;
+    }
+
+    public String getCustomerReference() {
+        return customerReference;
+    }
+
+    public void setCustomerReference(String customerReference) {
+        this.customerReference = customerReference;
     }
 
     public String getDescription() {

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/model/ItemData.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/model/ItemData.java
@@ -17,6 +17,8 @@ public class ItemData {
     @Field("id")
     private String id;
 
+    private String companyName;
+
     private String companyNumber;
 
     private String customerReference;
@@ -43,6 +45,14 @@ public class ItemData {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
     }
 
     public String getCompanyNumber() {

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/model/ItemData.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/model/ItemData.java
@@ -33,6 +33,8 @@ public class ItemData {
 
     private CertificateItemOptions itemOptions;
 
+    private String etag;
+
     private String kind;
 
     private Boolean isPostalDelivery;
@@ -109,6 +111,14 @@ public class ItemData {
 
     public void setItemOptions(CertificateItemOptions itemOptions) {
         this.itemOptions = itemOptions;
+    }
+
+    public String getEtag() {
+        return etag;
+    }
+
+    public void setEtag(String etag) {
+        this.etag = etag;
     }
 
     public String getKind() {

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/service/CertificateItemService.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/service/CertificateItemService.java
@@ -20,15 +20,18 @@ public class CertificateItemService {
     private final SequenceGeneratorService generator;
     private final DescriptionProviderService descriptions;
     private final CertificateCostCalculatorService calculator;
+    private final EtagGeneratorService etagGenerator;
 
     public CertificateItemService(final CertificateItemRepository repository,
                                   final SequenceGeneratorService generator,
                                   final DescriptionProviderService descriptions,
-                                  final CertificateCostCalculatorService calculator) {
+                                  final CertificateCostCalculatorService calculator,
+                                  final EtagGeneratorService etagGenerator) {
         this.repository = repository;
         this.generator = generator;
         this.descriptions = descriptions;
         this.calculator = calculator;
+        this.etagGenerator = etagGenerator;
     }
 
     /**
@@ -40,6 +43,7 @@ public class CertificateItemService {
         CERTIFICATE.populateReadOnlyFields(item, descriptions);
         item.setId(getNextId());
         setCreationDateTimes(item);
+        item.setEtag(etagGenerator.generateEtag());
         final CertificateItem itemSaved = repository.save(item);
         CERTIFICATE.populateItemCosts(itemSaved, calculator);
         return itemSaved;
@@ -54,6 +58,7 @@ public class CertificateItemService {
         final LocalDateTime now = LocalDateTime.now();
         updatedCertificateItem.setUpdatedAt(now);
         CERTIFICATE.populateDerivedDescriptionFields(updatedCertificateItem, descriptions);
+        updatedCertificateItem.setEtag(etagGenerator.generateEtag());
         final CertificateItem itemSaved = repository.save(updatedCertificateItem);
         CERTIFICATE.populateItemCosts(itemSaved, calculator);
         return itemSaved;

--- a/src/main/java/uk/gov/companieshouse/items/orders/api/service/EtagGeneratorService.java
+++ b/src/main/java/uk/gov/companieshouse/items/orders/api/service/EtagGeneratorService.java
@@ -1,0 +1,16 @@
+package uk.gov.companieshouse.items.orders.api.service;
+
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.GenerateEtagUtil;
+
+/**
+ * Service that uses {@link uk.gov.companieshouse.GenerateEtagUtil} to generate unique ETAG values.
+ */
+@Service
+public class EtagGeneratorService {
+
+    public String generateEtag() {
+        return GenerateEtagUtil.generateEtag();
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/ItemsApiApplicationTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/ItemsApiApplicationTest.java
@@ -28,6 +28,17 @@ class ItemsApiApplicationTest {
 		// No implementation required here to test that context loads.
 	}
 
+	@Test
+	@DisplayName("Create rejects missing company name")
+	void createCertificateItemRejectsMissingCompanyName() {
+		// Given
+		final CertificateItemDTO newCertificateItemDTO = createValidNewItem();
+		newCertificateItemDTO.setCompanyName(null);
+
+		// When and Then
+		postBadCreateRequestAndExpectError(newCertificateItemDTO, "company_name: must not be null");
+	}
+
     @Test
     @DisplayName("Create rejects missing company number")
     void createCertificateItemRejectsMissingCompanyNumber() {
@@ -196,6 +207,7 @@ class ItemsApiApplicationTest {
 	 */
 	private CertificateItemDTO createValidNewItem() {
 		final CertificateItemDTO newCertificateItemDTO = new CertificateItemDTO();
+		newCertificateItemDTO.setCompanyName("Smith & Co");
 		newCertificateItemDTO.setCompanyNumber("1234");
 		final CertificateItemOptions options = new CertificateItemOptions();
 		options.setDeliveryTimescale(STANDARD);

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerIntegrationTest.java
@@ -69,8 +69,6 @@ class CertificateItemsControllerIntegrationTest {
     private static final int SAME_DAY_EXTRA_CERTIFICATE_DISCOUNT = 40;
     private static final int STANDARD_INDIVIDUAL_CERTIFICATE_COST = 15;
     private static final int SAME_DAY_INDIVIDUAL_CERTIFICATE_COST = 50;
-    private static final boolean ORIGINAL_CERT_INC = true;
-    private static final boolean UPDATED_CERT_INC = false;
     private static final String ALTERNATIVE_CREATED_BY = "abc123";
     private static final String TOKEN_STRING = "TOKEN VALUE";
     static final Map<String, String> TOKEN_VALUES = new HashMap<>();
@@ -85,10 +83,11 @@ class CertificateItemsControllerIntegrationTest {
     private static final DeliveryTimescale UPDATED_DELIVERY_TIMESCALE = SAME_DAY;
     private static final String CUSTOMER_REFERENCE = "Certificate ordered by NJ.";
     private static final String UPDATED_CUSTOMER_REFERENCE = "Certificate ordered by PJ.";
-
     private static final String INVALID_DELIVERY_TIMESCALE_MESSAGE =
             "Cannot deserialize value of type `uk.gov.companieshouse.items.orders.api.model.DeliveryTimescale`"
            + " from String \"unknown\": value not one of declared Enum instance names: [same_day, standard]";
+    private static final String COMPANY_NAME = "Phillips & Daughters";
+    private static final String UPDATED_COMPANY_NAME = "Philips & Daughters";
 
     /**
      * Extends {@link PatchValidationCertificateItemDTO} to introduce a field that is unknown to the implementation.
@@ -115,6 +114,7 @@ class CertificateItemsControllerIntegrationTest {
     void createCertificateItemSuccessfullyCreatesCertificateItem() throws Exception {
         // Given
         final CertificateItemDTO newItem = new CertificateItemDTO();
+        newItem.setCompanyName(COMPANY_NAME);
         newItem.setCompanyNumber(COMPANY_NUMBER);
         final CertificateItemOptions options = new CertificateItemOptions();
         options.setDeliveryTimescale(DELIVERY_TIMESCALE);
@@ -171,7 +171,8 @@ class CertificateItemsControllerIntegrationTest {
         newItem.setQuantity(QUANTITY);
 
         final ApiError expectedValidationError =
-                new ApiError(BAD_REQUEST, singletonList("company_number: must not be null"));
+                new ApiError(BAD_REQUEST, asList("company_number: must not be null",
+                                                 "company_name: must not be null"));
 
         // When and Then
         mockMvc.perform(post("/certificates")
@@ -328,6 +329,7 @@ class CertificateItemsControllerIntegrationTest {
         savedItem.setId(EXPECTED_ITEM_ID);
         savedItem.setQuantity(QUANTITY);
         savedItem.setUserId(ERIC_IDENTITY_VALUE);
+        savedItem.setCompanyName(COMPANY_NAME);
         savedItem.setCompanyNumber(COMPANY_NUMBER);
         savedItem.setCustomerReference(CUSTOMER_REFERENCE);
         savedItem.setDescription(DESCRIPTION);
@@ -342,12 +344,14 @@ class CertificateItemsControllerIntegrationTest {
         itemUpdate.setQuantity(UPDATED_QUANTITY);
         options.setDeliveryTimescale(UPDATED_DELIVERY_TIMESCALE);
         itemUpdate.setItemOptions(options);
+        itemUpdate.setCompanyName(UPDATED_COMPANY_NAME);
         itemUpdate.setCompanyNumber(UPDATED_COMPANY_NUMBER);
         itemUpdate.setCustomerReference(UPDATED_CUSTOMER_REFERENCE);
 
         final CertificateItemDTO expectedItem = new CertificateItemDTO();
         expectedItem.setQuantity(UPDATED_QUANTITY);
         expectedItem.setItemOptions(options);
+        expectedItem.setCompanyName(UPDATED_COMPANY_NAME);
         expectedItem.setCompanyNumber(UPDATED_COMPANY_NUMBER);
         expectedItem.setCustomerReference(UPDATED_CUSTOMER_REFERENCE);
         expectedItem.setDescription(EXPECTED_DESCRIPTION);
@@ -382,6 +386,7 @@ class CertificateItemsControllerIntegrationTest {
         assertThat(retrievedCertificateItem.get().getQuantity(), is(UPDATED_QUANTITY));
         assertThat(retrievedCertificateItem.get().getItemOptions().getDeliveryTimescale(),
                 is(UPDATED_DELIVERY_TIMESCALE));
+        assertThat(retrievedCertificateItem.get().getCompanyName(), is(UPDATED_COMPANY_NAME));
 
         // Costs are calculated on the fly and are NOT to be saved to the DB.
         assertThat(retrievedCertificateItem.get().getItemCosts(), is(nullValue()));

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerIntegrationTest.java
@@ -179,10 +179,12 @@ class CertificateItemsControllerIntegrationTest {
         options.setDeliveryTimescale(DELIVERY_TIMESCALE);
         newItem.setItemOptions(options);
         newItem.setQuantity(QUANTITY);
+        newItem.setEtag(TOKEN_ETAG);
 
         final ApiError expectedValidationError =
                 new ApiError(BAD_REQUEST, asList("company_number: must not be null",
-                                                 "company_name: must not be null"));
+                                                 "company_name: must not be null",
+                                                 "etag: must be null"));
 
         // When and Then
         mockMvc.perform(post(CERTIFICATES_URL)
@@ -561,6 +563,7 @@ class CertificateItemsControllerIntegrationTest {
         itemUpdate.setDescriptionValues(TOKEN_VALUES);
         itemUpdate.setItemCosts(TOKEN_ITEM_COSTS);
         itemUpdate.setKind(TOKEN_STRING);
+        itemUpdate.setEtag(TOKEN_ETAG);
 
         final CertificateItem savedItem = new CertificateItem();
         savedItem.setId(EXPECTED_ITEM_ID);
@@ -571,7 +574,8 @@ class CertificateItemsControllerIntegrationTest {
         final ApiError expectedValidationErrors =
                 new ApiError(BAD_REQUEST, asList("description_values: must be null",
                                                  "item_costs: must be null",
-                                                 "kind: must be null"));
+                                                 "kind: must be null",
+                                                 "etag: must be null"));
 
         // When and then
         mockMvc.perform(patch(CERTIFICATES_URL + EXPECTED_ITEM_ID)

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerIntegrationTest.java
@@ -83,6 +83,8 @@ class CertificateItemsControllerIntegrationTest {
     private static final String COMPANY_NUMBER_KEY = "company_number";
     private static final DeliveryTimescale DELIVERY_TIMESCALE = STANDARD;
     private static final DeliveryTimescale UPDATED_DELIVERY_TIMESCALE = SAME_DAY;
+    private static final String CUSTOMER_REFERENCE = "Certificate ordered by NJ.";
+    private static final String UPDATED_CUSTOMER_REFERENCE = "Certificate ordered by PJ.";
 
     private static final String INVALID_DELIVERY_TIMESCALE_MESSAGE =
             "Cannot deserialize value of type `uk.gov.companieshouse.items.orders.api.model.DeliveryTimescale`"
@@ -118,6 +120,7 @@ class CertificateItemsControllerIntegrationTest {
         options.setDeliveryTimescale(DELIVERY_TIMESCALE);
         newItem.setItemOptions(options);
         newItem.setQuantity(QUANTITY);
+        newItem.setCustomerReference(CUSTOMER_REFERENCE);
 
         final CertificateItemDTO expectedItem = new CertificateItemDTO();
         expectedItem.setId(EXPECTED_ITEM_ID);
@@ -134,6 +137,7 @@ class CertificateItemsControllerIntegrationTest {
         expectedItem.setItemOptions(options);
         expectedItem.setPostalDelivery(true);
         expectedItem.setQuantity(QUANTITY);
+        expectedItem.setCustomerReference(CUSTOMER_REFERENCE);
 
         // When and Then
         mockMvc.perform(post("/certificates")
@@ -227,6 +231,7 @@ class CertificateItemsControllerIntegrationTest {
         newItem.setId(EXPECTED_ITEM_ID);
         newItem.setQuantity(QUANTITY);
         newItem.setUserId(ERIC_IDENTITY_VALUE);
+        newItem.setCustomerReference(CUSTOMER_REFERENCE);
         repository.save(newItem);
 
         final CertificateItemDTO expectedItem = new CertificateItemDTO();
@@ -240,6 +245,7 @@ class CertificateItemsControllerIntegrationTest {
         costs.setPostageCost(POSTAGE_COST);
         costs.setTotalCost(Integer.toString(QUANTITY * STANDARD_INDIVIDUAL_CERTIFICATE_COST - expectedDiscountApplied));
         expectedItem.setItemCosts(costs);
+        expectedItem.setCustomerReference(CUSTOMER_REFERENCE);
 
         // When and then
         mockMvc.perform(get("/certificates/"+EXPECTED_ITEM_ID)
@@ -323,6 +329,7 @@ class CertificateItemsControllerIntegrationTest {
         savedItem.setQuantity(QUANTITY);
         savedItem.setUserId(ERIC_IDENTITY_VALUE);
         savedItem.setCompanyNumber(COMPANY_NUMBER);
+        savedItem.setCustomerReference(CUSTOMER_REFERENCE);
         savedItem.setDescription(DESCRIPTION);
         savedItem.setDescriptionValues(singletonMap(COMPANY_NUMBER_KEY, COMPANY_NUMBER));
 
@@ -336,11 +343,13 @@ class CertificateItemsControllerIntegrationTest {
         options.setDeliveryTimescale(UPDATED_DELIVERY_TIMESCALE);
         itemUpdate.setItemOptions(options);
         itemUpdate.setCompanyNumber(UPDATED_COMPANY_NUMBER);
+        itemUpdate.setCustomerReference(UPDATED_CUSTOMER_REFERENCE);
 
         final CertificateItemDTO expectedItem = new CertificateItemDTO();
         expectedItem.setQuantity(UPDATED_QUANTITY);
         expectedItem.setItemOptions(options);
         expectedItem.setCompanyNumber(UPDATED_COMPANY_NUMBER);
+        expectedItem.setCustomerReference(UPDATED_CUSTOMER_REFERENCE);
         expectedItem.setDescription(EXPECTED_DESCRIPTION);
         expectedItem.setDescriptionValues(singletonMap(COMPANY_NUMBER_KEY, UPDATED_COMPANY_NUMBER));
 

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/controller/CertificateItemsControllerIntegrationTest.java
@@ -559,7 +559,7 @@ class CertificateItemsControllerIntegrationTest {
 
     @Test
     @DisplayName("Rejects update request containing an invalid delivery timescale")
-    void updateCertificateItemRejectsMultipleReadOnlyFields2() throws Exception {
+    void updateCertificateItemRejectsInvalidDeliveryTimescale() throws Exception {
         // Given
         final PatchValidationCertificateItemDTO itemUpdate = new PatchValidationCertificateItemDTO();
         final CertificateItemOptions options = new CertificateItemOptions();

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/mapper/CertificateItemMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/mapper/CertificateItemMapperTest.java
@@ -36,7 +36,7 @@ public class CertificateItemMapperTest {
     private static final ItemCosts ITEM_COSTS = new ItemCosts("1", "2", "3", "4");
     private static final String KIND = "certificate";
     private static final boolean POSTAL_DELIVERY = true;
-    private static final boolean CERT_ACC = true;
+    private static final String CUSTOMER_REFERENCE = "Certificate ordered by NJ.";
 
     private static final CertificateItemOptions ITEM_OPTIONS;
 
@@ -57,6 +57,7 @@ public class CertificateItemMapperTest {
         final CertificateItemDTO dto = new CertificateItemDTO();
         dto.setId(ID);
         dto.setCompanyNumber(COMPANY_NUMBER);
+        dto.setCustomerReference(CUSTOMER_REFERENCE);
         dto.setQuantity(QUANTITY);
         dto.setDescription(DESCRIPTION);
         dto.setDescriptionIdentifier(DESCRIPTION_IDENTIFIER);
@@ -71,6 +72,7 @@ public class CertificateItemMapperTest {
         assertThat(item.getData(), is(notNullValue()));
         assertThat(item.getData().getId(), is(dto.getId()));
         assertThat(item.getCompanyNumber(), is(dto.getCompanyNumber()));
+        assertThat(item.getCustomerReference(), is(dto.getCustomerReference()));
         assertThat(item.getQuantity(), is(dto.getQuantity()));
         assertThat(item.getDescription(), is(dto.getDescription()));
         assertThat(item.getDescriptionIdentifier(), is(dto.getDescriptionIdentifier()));
@@ -86,6 +88,7 @@ public class CertificateItemMapperTest {
         final CertificateItem item = new CertificateItem();
         item.setId(ID);
         item.setCompanyNumber(COMPANY_NUMBER);
+        item.setCustomerReference(CUSTOMER_REFERENCE);
         item.setQuantity(QUANTITY);
         item.setDescription(DESCRIPTION);
         item.setDescriptionIdentifier(DESCRIPTION_IDENTIFIER);
@@ -98,6 +101,7 @@ public class CertificateItemMapperTest {
 
         assertThat(dto.getId(), is(item.getId()));
         assertThat(dto.getCompanyNumber(), is(item.getCompanyNumber()));
+        assertThat(dto.getCustomerReference(), is(item.getCustomerReference()));
         assertThat(dto.getQuantity(), is(item.getQuantity()));
         assertThat(dto.getDescription(), is(item.getDescription()));
         assertThat(dto.getDescriptionIdentifier(), is(item.getDescriptionIdentifier()));

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/mapper/CertificateItemMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/mapper/CertificateItemMapperTest.java
@@ -37,6 +37,7 @@ public class CertificateItemMapperTest {
     private static final String KIND = "certificate";
     private static final boolean POSTAL_DELIVERY = true;
     private static final String CUSTOMER_REFERENCE = "Certificate ordered by NJ.";
+    private static final String COMPANY_NAME = "Phillips & Daughters";
 
     private static final CertificateItemOptions ITEM_OPTIONS;
 
@@ -56,6 +57,7 @@ public class CertificateItemMapperTest {
     void testCertificateItemDtoToEntityMapping() {
         final CertificateItemDTO dto = new CertificateItemDTO();
         dto.setId(ID);
+        dto.setCompanyName(COMPANY_NAME);
         dto.setCompanyNumber(COMPANY_NUMBER);
         dto.setCustomerReference(CUSTOMER_REFERENCE);
         dto.setQuantity(QUANTITY);
@@ -71,6 +73,7 @@ public class CertificateItemMapperTest {
         assertThat(item.getId(), is(dto.getId()));
         assertThat(item.getData(), is(notNullValue()));
         assertThat(item.getData().getId(), is(dto.getId()));
+        assertThat(item.getCompanyName(), is(dto.getCompanyName()));
         assertThat(item.getCompanyNumber(), is(dto.getCompanyNumber()));
         assertThat(item.getCustomerReference(), is(dto.getCustomerReference()));
         assertThat(item.getQuantity(), is(dto.getQuantity()));
@@ -87,6 +90,7 @@ public class CertificateItemMapperTest {
     void testCertificateItemEntityToDtoMapping() {
         final CertificateItem item = new CertificateItem();
         item.setId(ID);
+        item.setCompanyName(COMPANY_NAME);
         item.setCompanyNumber(COMPANY_NUMBER);
         item.setCustomerReference(CUSTOMER_REFERENCE);
         item.setQuantity(QUANTITY);
@@ -100,6 +104,7 @@ public class CertificateItemMapperTest {
         final CertificateItemDTO dto = mapperUnderTest.certificateItemToCertificateItemDTO(item);
 
         assertThat(dto.getId(), is(item.getId()));
+        assertThat(dto.getCompanyName(), is(item.getCompanyName()));
         assertThat(dto.getCompanyNumber(), is(item.getCompanyNumber()));
         assertThat(dto.getCustomerReference(), is(item.getCustomerReference()));
         assertThat(dto.getQuantity(), is(item.getQuantity()));

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/mapper/CertificateItemMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/mapper/CertificateItemMapperTest.java
@@ -38,6 +38,7 @@ public class CertificateItemMapperTest {
     private static final boolean POSTAL_DELIVERY = true;
     private static final String CUSTOMER_REFERENCE = "Certificate ordered by NJ.";
     private static final String COMPANY_NAME = "Phillips & Daughters";
+    private static final String TOKEN_ETAG = "9d39ea69b64c80ca42ed72328b48c303c4445e28";
 
     private static final CertificateItemOptions ITEM_OPTIONS;
 
@@ -101,6 +102,8 @@ public class CertificateItemMapperTest {
         item.setKind(KIND);
         item.setPostalDelivery(POSTAL_DELIVERY);
         item.setItemOptions(ITEM_OPTIONS);
+        item.setEtag(TOKEN_ETAG);
+
         final CertificateItemDTO dto = mapperUnderTest.certificateItemToCertificateItemDTO(item);
 
         assertThat(dto.getId(), is(item.getId()));
@@ -115,6 +118,7 @@ public class CertificateItemMapperTest {
         assertThat(dto.getKind(), is(item.getKind()));
         assertThat(dto.isPostalDelivery(), is(item.isPostalDelivery()));
         assertThat(dto.getItemOptions(), is(item.getItemOptions()));
+        assertThat(dto.getEtag(), is(item.getEtag()));
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/service/CertificateItemServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/service/CertificateItemServiceTest.java
@@ -20,8 +20,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static uk.gov.companieshouse.items.orders.api.model.DeliveryTimescale.STANDARD;
 
 /**
@@ -58,6 +57,9 @@ class CertificateItemServiceTest {
     @Mock
     private CertificateCostCalculatorService calculator;
 
+    @Mock
+    private EtagGeneratorService etagGenerator;
+
     @Test
     @DisplayName("getNextId gets the expected next ID value")
     void getNextIdGetsNextId() {
@@ -67,10 +69,11 @@ class CertificateItemServiceTest {
 
         // When and Then
         assertThat(serviceUnderTest.getNextId(), is(EXPECTED_ID_VALUE));
+        verify(etagGenerator, never()).generateEtag();
     }
 
     @Test
-    @DisplayName("createCertificateItem creates and saves item with timestamps, returns item with costs")
+    @DisplayName("createCertificateItem creates and saves item with timestamps, generates etag, returns item with costs")
     void createCertificateItemPopulatesAndSavesItem() {
 
         // Given
@@ -89,10 +92,11 @@ class CertificateItemServiceTest {
         verifyCreationTimestampsWithinExecutionInterval(item, intervalStart, intervalEnd);
         verify(repository).save(item);
         verifyCostsFields(item);
+        verify(etagGenerator).generateEtag();
     }
 
     @Test
-    @DisplayName("saveCertificateItem saves item, updates updated at timestamp, returns item with costs")
+    @DisplayName("saveCertificateItem saves item, updates updated at timestamp, generates etag, returns item with costs")
     void saveCertificateItemUpdatesCertificateItem() {
 
         // Given
@@ -110,6 +114,7 @@ class CertificateItemServiceTest {
         verify(repository).save(item);
         verifyCostsFields(item);
         verifyUpdatedAtTimestampWithinExecutionInterval(item, intervalStart, intervalEnd);
+        verify(etagGenerator).generateEtag();
     }
 
     @Test
@@ -127,6 +132,7 @@ class CertificateItemServiceTest {
         verify(repository).findById(ITEM_SOUGHT_ID_VALUE);
         assertThat(itemRetrieved.isPresent(), is(true));
         verifyCostsFields(itemRetrieved.get());
+        verify(etagGenerator, never()).generateEtag();
     }
 
     @Test
@@ -144,6 +150,7 @@ class CertificateItemServiceTest {
         verify(repository).findById(ITEM_SOUGHT_ID_VALUE);
         assertThat(itemRetrieved.isPresent(), is(true));
         assertThat(itemRetrieved.get().getItemCosts(), is(nullValue()));
+        verify(etagGenerator, never()).generateEtag();
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/items/orders/api/validator/PatchItemRequestValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/validator/PatchItemRequestValidatorTest.java
@@ -144,6 +144,13 @@ class PatchItemRequestValidatorTest {
     }
 
     @Test
+    @DisplayName("Etag is read only")
+    void getValidationErrorsRejectsReadOnlyEtag() throws IOException {
+        itemUpdate.setEtag(TOKEN_STRING);
+        assertFieldMustBeNullErrorProduced("etag");
+    }
+
+    @Test
     @DisplayName("Postal delivery is read only")
     void getValidationErrorsRejectsReadOnlyPostalDelivery() throws IOException {
         itemUpdate.setPostalDelivery(TOKEN_POSTAL_DELIVERY_VALUE);
@@ -157,6 +164,7 @@ class PatchItemRequestValidatorTest {
         itemUpdate.setDescriptionValues(TOKEN_VALUES);
         itemUpdate.setItemCosts(TOKEN_ITEM_COSTS);
         itemUpdate.setKind(TOKEN_STRING);
+        itemUpdate.setEtag(TOKEN_STRING);
         final JsonMergePatch patch = patchFactory.patchFromPojo(itemUpdate);
 
         // When
@@ -166,7 +174,8 @@ class PatchItemRequestValidatorTest {
         assertThat(errors,
                 containsInAnyOrder("description_values: must be null",
                                    "item_costs: must be null",
-                                   "kind: must be null"));
+                                   "kind: must be null",
+                                   "etag: must be null"));
     }
 
     @Test

--- a/src/test/postman/Items_API.postman_collection.json
+++ b/src/test/postman/Items_API.postman_collection.json
@@ -328,6 +328,40 @@
 										}
 									},
 									"response": []
+								},
+								{
+									"name": "Create certificate item read only etag",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"company_name\": \"Smith & Co\",\t\n\t\"company_number\": \"00006400\",\n\t\"etag\": \"9d39ea69b64c80ca42ed72328b48c303c4445e28\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{base_url}}/orderable/certificates",
+											"host": [
+												"{{base_url}}"
+											],
+											"path": [
+												"orderable",
+												"certificates"
+											]
+										}
+									},
+									"response": []
 								}
 							],
 							"description": "Test what happen when requests are made containing values for read only attributes.",
@@ -460,6 +494,46 @@
 							"response": []
 						},
 						{
+							"name": "Update certificate item read only etag",
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/merge-patch+json"
+									},
+									{
+										"key": "X-Request-ID",
+										"type": "text",
+										"value": "f058ebd6-02f7-4d3f-942e-904344e8cde5"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"company_name\": \"Smyth & Co\",\n\t\"company_number\": \"00006777\",\n\t\"customer_reference\": \"Certificate ordered by NJ.\",\n\t\"etag\": \"9d39ea69b64c80ca42ed72328b48c303c4445e28\",\n\t\"item_options\": {\n    \t\"delivery_timescale\": \"standard\"\n\t},\n\t\"quantity\": 2\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/orderable/certificates/CHS00000000000000154",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"orderable",
+										"certificates",
+										"CHS00000000000000154"
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "Update certificate item bad timescale",
 							"request": {
 								"method": "PATCH",
@@ -584,7 +658,7 @@
 		"oauth2": [
 			{
 				"key": "accessToken",
-				"value": "X8ltu6H4RwSEM_rDmvWLpnhDQ62UkSNzozKHViexRzORZsmnvkwhFP3HgKozFmOhxFu5KLF2Ya1cCEEs0dAWfw",
+				"value": "",
 				"type": "string"
 			},
 			{

--- a/src/test/postman/Items_API.postman_collection.json
+++ b/src/test/postman/Items_API.postman_collection.json
@@ -16,7 +16,7 @@
 							"name": "Missing attributes",
 							"item": [
 								{
-									"name": "Create certificate item missing company number",
+									"name": "Create certificate item missing company name and number",
 									"request": {
 										"method": "POST",
 										"header": [
@@ -63,7 +63,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"company_number\": \"00006400\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    }\n}",
+											"raw": "{\n\t\"company_name\": \"Smith & Co\",\n\t\"company_number\": \"00006400\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -97,7 +97,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"company_number\": \"000064000\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
+											"raw": "{\n\t\"company_name\": \"Smith & Co\",\n\t\"company_number\": \"000064000\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -131,7 +131,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"quantity\": 3\n}",
+											"raw": "{\n\t\"company_name\": \"Smith & Co\",\n\t\"company_number\": \"00006400\",\n\t\"quantity\": 3\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -173,7 +173,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"item_costs\": {},\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
+											"raw": "{\n\t\"company_name\": \"Smith & Co\",\n\t\"company_number\": \"00006400\",\n\t\"item_costs\": {},\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -207,7 +207,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"description\": \"description text\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
+											"raw": "{\n\t\"company_name\": \"Smith & Co\",\n\t\"company_number\": \"00006400\",\n\t\"description\": \"description text\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -241,7 +241,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"description_identifier\": \"description identifier text\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
+											"raw": "{\n\t\"company_name\": \"Smith & Co\",\n\t\"company_number\": \"00006400\",\n\t\"description_identifier\": \"description identifier text\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -275,7 +275,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"description_values\": {},\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+											"raw": "{\n\t\"company_name\": \"Smith & Co\",\n\t\"company_number\": \"00006400\",\n\t\"description_values\": {},\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -309,7 +309,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"id\": \"1\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
+											"raw": "{\n\t\"company_name\": \"Smith & Co\",\t\n\t\"company_number\": \"00006400\",\n\t\"id\": \"1\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -392,7 +392,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"company_number\": \"00006400\",\n    \"item_options\": {\n        \"delivery_timescale\": \"unknown\"\n    },\n\t\"quantity\": 3\n}",
+									"raw": "{\n\t\"company_name\": \"Smith & Co\",\t\n\t\"company_number\": \"00006400\",\n    \"item_options\": {\n        \"delivery_timescale\": \"unknown\"\n    },\n\t\"quantity\": 3\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -438,7 +438,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"company_number\": \"00006777\",\n\t\"customer_reference\": \"Certificate ordered by NJ.\",\n\t\"item_options\": {\n    \t\"delivery_timescale\": \"standard\"\n\t},\n\t\"quantity\": 2\n}",
+									"raw": "{\n\t\"company_name\": \"Smyth & Co\",\n\t\"company_number\": \"00006777\",\n\t\"customer_reference\": \"Certificate ordered by NJ.\",\n\t\"item_options\": {\n    \t\"delivery_timescale\": \"standard\"\n\t},\n\t\"quantity\": 2\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -446,14 +446,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{base_url}}/orderable/certificates/CHS00000000000000138",
+									"raw": "{{base_url}}/orderable/certificates/CHS00000000000000152",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"orderable",
 										"certificates",
-										"CHS00000000000000138"
+										"CHS00000000000000152"
 									]
 								}
 							},
@@ -493,7 +493,7 @@
 									"path": [
 										"orderable",
 										"certificates",
-										"CHS00000000000000037"
+										"CHS00000000000000138"
 									]
 								}
 							},
@@ -558,14 +558,14 @@
 									}
 								],
 								"url": {
-									"raw": "{{base_url}}/orderable/certificates/CHS00000000000000001",
+									"raw": "{{base_url}}/orderable/certificates/CHS00000000000000137",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
 										"orderable",
 										"certificates",
-										"CHS00000000000000001"
+										"CHS00000000000000137"
 									]
 								}
 							},
@@ -584,7 +584,7 @@
 		"oauth2": [
 			{
 				"key": "accessToken",
-				"value": "",
+				"value": "X8ltu6H4RwSEM_rDmvWLpnhDQ62UkSNzozKHViexRzORZsmnvkwhFP3HgKozFmOhxFu5KLF2Ya1cCEEs0dAWfw",
 				"type": "string"
 			},
 			{

--- a/src/test/postman/Items_API.postman_collection.json
+++ b/src/test/postman/Items_API.postman_collection.json
@@ -29,7 +29,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+											"raw": "{\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -63,7 +63,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"company_number\": \"00006400\",\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    }\n}",
+											"raw": "{\n\t\"company_number\": \"00006400\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -97,7 +97,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"company_number\": \"000064000\",\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+											"raw": "{\n\t\"company_number\": \"000064000\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -173,7 +173,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"item_costs\": {},\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"item_costs\": {},\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -207,7 +207,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"description\": \"description text\",\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"description\": \"description text\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -241,7 +241,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"description_identifier\": \"description identifier text\",\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"description_identifier\": \"description identifier text\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -309,7 +309,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"id\": \"1\",\n    \"item_options\": {\n        \"additional_information\": \"Certificate required by HMRC.\",\n        \"cert_acc\": false,\n        \"cert_arts\": false,\n        \"cert_cobj\": false,\n        \"cert_dir\": false,\n        \"cert_dissliq\": false,\n        \"cert_domicil\": false,\n        \"cert_extra_i\": false,\n        \"cert_inc\": true,\n        \"cert_inc_con_last\": false,\n        \"cert_isscap\": false,\n        \"cert_mem\": false,\n        \"cert_mortdoc\": false,\n        \"cert_nomc\": false,\n        \"cert_nonexis\": false,\n        \"cert_only\": false,\n        \"cert_other_c\": false,\n        \"cert_ret\": false,\n        \"cert_roc\": false,\n        \"cert_sec\": false,\n        \"cert_shar\": true\n    },\n\t\"quantity\": 3\n}",
+											"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"id\": \"1\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -353,7 +353,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"company_number\": \"00006400\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
+									"raw": "{\n\t\"company_number\": \"00006400\",\n\t\"customer_reference\": \"Certificate ordered by OJ.\",\n    \"item_options\": {\n        \"delivery_timescale\": \"same_day\"\n    },\n\t\"quantity\": 3\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -438,7 +438,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"company_number\": \"00006777\",\n\t\"item_options\": {\n    \t\"delivery_timescale\": \"standard\"\n\t},\n\t\"quantity\": 2\n}",
+									"raw": "{\n\t\"company_number\": \"00006777\",\n\t\"customer_reference\": \"Certificate ordered by NJ.\",\n\t\"item_options\": {\n    \t\"delivery_timescale\": \"standard\"\n\t},\n\t\"quantity\": 2\n}",
 									"options": {
 										"raw": {
 											"language": "json"


### PR DESCRIPTION
These top-level fields seen in the current API spec do not appear in the current API implementation:

- company_name
- customer_reference
- etag