### PR TITLE
Amended test as expect/actual in wrong order causing sonar issue

### DIFF
--- a/src/test/java/uk/gov/companieshouse/items/orders/api/mapper/CertificateItemMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/items/orders/api/mapper/CertificateItemMapperTest.java
@@ -167,9 +167,9 @@ public class CertificateItemMapperTest {
         assertThat(item.getKind(), is(dto.getKind()));
         assertThat(item.isPostalDelivery(), is(dto.isPostalDelivery()));
         CertificateItemOptions itemOptions = item.getItemOptions();
-        assertEquals(itemOptions.getCertificateType(), NO_DEFAULT_CERTIFICATE_TYPE);
-        assertEquals(itemOptions.getDeliveryMethod(), NO_DEFAULT_DELIVERY_METHOD);
-        assertEquals(itemOptions.getDeliveryTimescale(), NO_DEFAULT_DELIVERY_TIMESCALE);
+        assertEquals(NO_DEFAULT_CERTIFICATE_TYPE, itemOptions.getCertificateType());
+        assertEquals(NO_DEFAULT_DELIVERY_METHOD, itemOptions.getDeliveryMethod());
+        assertEquals(NO_DEFAULT_DELIVERY_TIMESCALE, itemOptions.getDeliveryTimescale());
         assertThat(item.getPostageCost(), is(dto.getPostageCost()));
         assertThat(item.getTotalItemCost(), is(dto.getTotalItemCost()));
     }


### PR DESCRIPTION
Amended CertificateItemMapperTest as some assertions had the expected and actual values the wrong way round, causing sonar issues.